### PR TITLE
Module specific ErrorController was not being called

### DIFF
--- a/Controller/Plugin/ErrorControllerSwitcher.php
+++ b/Controller/Plugin/ErrorControllerSwitcher.php
@@ -1,0 +1,19 @@
+<?php
+class REST_Controller_Plugin_ErrorControllerSwitcher extends Zend_Controller_Plugin_Abstract
+{
+    public function routeShutdown (Zend_Controller_Request_Abstract $request)
+    {
+        $front = Zend_Controller_Front::getInstance();
+        if (!($front->getPlugin('Zend_Controller_Plugin_ErrorHandler') instanceof Zend_Controller_Plugin_ErrorHandler)) {
+            return;
+        }
+        $error = $front->getPlugin('Zend_Controller_Plugin_ErrorHandler');
+        $testRequest = new Zend_Controller_Request_HTTP();
+        $testRequest->setModuleName($request->getModuleName())
+                    ->setControllerName($error->getErrorHandlerController())
+                    ->setActionName($error->getErrorHandlerAction());
+        if ($front->getDispatcher()->isDispatchable($testRequest)) {
+            $error->setErrorHandlerModule($request->getModuleName());
+        }
+    }
+}


### PR DESCRIPTION
I have set of REST and non REST modules -- and it appears that the REST module was always getting the default ErrorController instead of the module specific one. (so I end up with a mixup of xml and html in the error response). This problem seems to be solved by others using this plugin.

Implementation based on http://www.toosweettobesour.com/2008/08/11/quickie-module-specific-error-controllers-in-zend-framework-15/

Register in bootstrap:
$frontController->registerPlugin( new REST_Controller_Plugin_ErrorControllerSwitcher() );

Signed-off-by: Todd Brannam tbrannam@casualpenguin.com
