### PR TITLE
Default format when no specified

### DIFF
--- a/Controller/Plugin/RestHandler.php
+++ b/Controller/Plugin/RestHandler.php
@@ -78,6 +78,10 @@ class REST_Controller_Plugin_RestHandler extends Zend_Controller_Plugin_Abstract
             $format = $request->getParam('format');
         } else {
             $bestMimeType = $this->negotiateContentType($request);
+            
+            //If still there's no any MimeType, assign default XML
+            if(!$bestMimeType || $bestMimeType == '*/*') $bestMimeType = 'application/xml';
+            
             $format = $this->responseTypes[$bestMimeType];
         }
 


### PR DESCRIPTION
There's an issue: When the user that make the calls to the REST server doesn't specify any format, the system must to take any as default. This triggers the error that the MIME is invalid:
1. If the user doesn't have the HTTP PECL extension installed, the MIME returned is empty.
2. If the user has the HTTP PECT extension, the MIME returned is '_/_'

The user is free to specify or not the format.
My change is to set 'application/xml' the default MimeType when there's format specified.
