### PR TITLE
silently escape getReflectionClass if controller name equals false

### DIFF
--- a/Controller/Plugin/RestHandler.php
+++ b/Controller/Plugin/RestHandler.php
@@ -295,6 +295,9 @@ class REST_Controller_Plugin_RestHandler extends Zend_Controller_Plugin_Abstract
         if ($this->reflectionClass === null) {
             // get the dispatcher to load the controller class
             $controller = $this->dispatcher->getControllerClass($request);
+            // if no controller present escape silently...
+            if ($controller === false) return false;
+            // ... load controller class
             $className  = $this->dispatcher->loadClass($controller);
 
             // extract the actions through reflection


### PR DESCRIPTION
in some situations there will be no controller in the dispatcher given. to get around this, i break the getReflectionClass method returning false.
